### PR TITLE
Make it isomorphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ import { HttpAdapter, Model } from '@itsfadnis/jsonapi-client';
 
 // Setup an instance of the adapter for the model
 Model.adapter = new HttpAdapter({
+  // Defaults to `${window.location.protocol}//${window.location.host}`
   baseURL: 'https://foo.com',
+  // Defaults to ''
   namespace: '/v2',
   headers: {
     key: 'value'
-  }
+  },
+  // The adapter uses the Fetch API for making network requests
+  // You can pass it in as an option, else it will default to window.fetch
+  fetch: window.fetch
 });
 ```
 

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -8,6 +8,7 @@ class HttpAdapter {
       HTTP_X_REQUESTED_WITH: 'XMLHttpRequest',
       ...args.headers
     };
+    this.fetch = args.fetch || window.fetch;
   }
 
   get(url) {
@@ -39,13 +40,11 @@ class HttpAdapter {
   }
 
   request(method, url, data) {
-    const request = new Request(this.baseURL + this.namespace + url, {
+    return this.fetch(this.baseURL + this.namespace + url, {
       method,
       headers: this.headers,
       body: data && JSON.stringify(data)
-    });
-
-    return fetch(request).then((response) => {
+    }).then((response) => {
       const payload = {
         status: response.status,
         statusText: response.statusText,


### PR DESCRIPTION
- The adapter can now accept `fetch` as an argument, and work with it to make requests.
- It can now work on node js if `fetch` and `baseURL` are passed in while configuring the adapter