### PR TITLE
Fixed X-Requested-With header

### DIFF
--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -5,7 +5,7 @@ class HttpAdapter {
     this.headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      HTTP_X_REQUESTED_WITH: 'XMLHttpRequest',
+      'X-Requested-With': 'XMLHttpRequest',
       ...args.headers
     };
     this.fetch = args.fetch || window.fetch;


### PR DESCRIPTION
HTTP_X_REQUESTED_WITH is how this header appears in PHP, not how it is transmitted over HTTP. The header should be sent as X-Requested-With.