### PR TITLE
refactor!: package api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itsfadnis/jsonapi-client",
   "version": "2.1.4",
-  "main": "dist/index.js",
+  "main": "dist/model.js",
   "scripts": {
     "build": "tsc",
     "lint": "eslint **/*.ts --fix",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,0 @@
-import HttpAdapter from './http-adapter';
-import Model from './model';
-import JSONAPIError from './jsonapi-error';
-
-export default { HttpAdapter, Model, JSONAPIError };

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -421,41 +421,15 @@ describe('Model', () => {
     });
   });
 
-  describe('#save()', () => {
-    describe('on invalid model', () => {
+  describe('#save(), on a invalid model', () => {
+    test('it throws a 422 error', () => {
       const model = new Model();
       jest.spyOn(model, 'valid', 'get').mockReturnValue(false);
       expect(model.save()).rejects.toEqual(new Error('Unprocessable Entity'));
     });
-
-    describe('on persisted model', () => {
-      test('it calls & returns #_update()', () => {
-        const model = new Model();
-        model.persisted = true;
-        model._update = jest.fn().mockReturnValue('something');
-
-        const returnValue = model.save();
-
-        expect(returnValue).toBe('something');
-        expect(model._update).toHaveBeenCalled();
-      });
-    });
-
-    describe('on new model', () => {
-      test('it calls & returns #_create()', () => {
-        const model = new Model();
-        model.persisted = false;
-        model._create = jest.fn().mockReturnValue('something');
-
-        const returnValue = model.save();
-
-        expect(returnValue).toBe('something');
-        expect(model._create).toHaveBeenCalled();
-      });
-    });
   });
 
-  describe('#_create()', () => {
+  describe('#save(), on a new model', () => {
     beforeEach(() => {
       Model.configureAdapter();
     });
@@ -486,7 +460,7 @@ describe('Model', () => {
         const deserializeSpy = jest.spyOn(Model, 'deserialize').mockResolvedValue(mockDeserializedObject);
 
         const model = new Model();
-        return model._create().then((response) => {
+        return model.save().then((response) => {
           expect(postSpy).toHaveBeenCalledWith(model.constructBaseURL(), mockSerializedObject);
           expect(serializeSpy).toHaveBeenCalled();
           expect(deserializeSpy).toHaveBeenCalledWith(mockResponse.data);
@@ -511,7 +485,7 @@ describe('Model', () => {
         });
         const model = new Model();
 
-        return model._create().catch((response) => {
+        return model.save().catch((response) => {
           expect(postSpy).toHaveBeenCalledWith(model.constructBaseURL(), { foo: 'bar' });
           expect(serializeSpy).toHaveBeenCalled();
           expect(response).toEqual(mockResponse);
@@ -522,7 +496,7 @@ describe('Model', () => {
     });
   });
 
-  describe('#_update()', () => {
+  describe('#save(), on an existing model', () => {
     beforeEach(() => {
       Model.configureAdapter();
     });
@@ -558,7 +532,7 @@ describe('Model', () => {
           id: '123',
         });
 
-        return model._update().then((response) => {
+        return model.save().then((response) => {
           expect(patchSpy).toHaveBeenCalledWith(`${model.constructBaseURL()}/123`, mockSerializedObject);
           expect(serializeSpy).toHaveBeenCalled();
           expect(deserializeSpy).toHaveBeenCalledWith(mockResponse.data);
@@ -596,7 +570,7 @@ describe('Model', () => {
           id: '123',
         });
 
-        return model._update().catch((response) => {
+        return model.save().catch((response) => {
           expect(patchSpy).toHaveBeenCalledWith(`${model.constructBaseURL()}/123`, mockSerializedObject);
           expect(serializeSpy).toHaveBeenCalled();
           expect(model.errors).toEqual(new JSONAPIError(response.data));


### PR DESCRIPTION
## Code refactor:
- Make #_update & #_create methods private
- Extract identical error handler into common method

## Package refactor:
- Main export is now `model.js`. Idea being the package consumer should never need to import any other module (`adapter` or `error`) directly.